### PR TITLE
Feature/ros nodes

### DIFF
--- a/src/driver.py
+++ b/src/driver.py
@@ -1,11 +1,12 @@
+#!/usr/bin/env python3
 import rospy
 
 #TODO: change "point" to a real data type
 #TODO: make the publishers publish a legitimate output
 class Driver:
-    rate = rospy.Rate(10)
-    def __init__():
+    def __init__(self):
         rospy.init_node('driver', anonymous=False)
+        self.rate = rospy.Rate(10)
 
     def goal_position_publish(self):
         goal_pos_publish  = rospy.Publisher('goal_position_publish', "point", queue_size=10)
@@ -44,7 +45,7 @@ class Driver:
         rospy.spin()
 
     def vision_status_subscribe():
-        rospy.Subscriber("vision_status_publish", "callback?")
+        rospy.Subscriber("vision_vitals_publish", "callback?")
         rospy.spin()
 
 

--- a/src/dynamixel_driver.py
+++ b/src/dynamixel_driver.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 from utils.dynamixel_handler import DynamixelHandler
 import time
 

--- a/src/odometry.py
+++ b/src/odometry.py
@@ -1,10 +1,11 @@
+#!/usr/bin/env python3
 import rospy
 
 class Odometry():
 
-    rate = rospy.Rate(10)
-    def __init__():
+    def __init__(self):
         rospy.init_node("odometry", anonymous=False)
+        rate = rospy.Rate(10)
 
     def odometry_publish(self):
         shifter_publish = rospy.Publisher("odometry_publish", "point", queue_size=10)

--- a/src/shifter.py
+++ b/src/shifter.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import rospy
 from custom_types.msg import Status
 
@@ -5,8 +6,8 @@ class Shifter():
     def __init__(self):
         # Initialize the node
         try:
-            self.rate = rospy.Rate(10) # Hz
             rospy.init_node("shifter", anonymous=False)
+            self.rate = rospy.Rate(10) # Hz
         except Exception as e:
             rospy.logerr(f"Failed to initialize shifter: {e}")
             raise

--- a/src/utils/dynamixel_handler.py
+++ b/src/utils/dynamixel_handler.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 """ Manages the dynamixel motors used within the robot """
 from dynamixel_sdk import PortHandler, PacketHandler
 

--- a/src/velocity_to_drive.py
+++ b/src/velocity_to_drive.py
@@ -1,10 +1,11 @@
+#!/usr/bin/env python3
 import rospy
 
 class VelocityToDrive():
 
-    rate = rospy.Rate(10)
-    def __init__():
+    def __init__(self):
         rospy.init_node("velocity_to_drive", anonymous=False)
+        self.rate = rospy.Rate(10)
 
     def goal_status_publish(self):
         shifter_publish = rospy.Publisher("goal_status_publish", "status_type", queue_size=10)

--- a/src/velocity_to_intake.py
+++ b/src/velocity_to_intake.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import rospy
 
 class VelocityToIntake():

--- a/src/velocity_to_outtake.py
+++ b/src/velocity_to_outtake.py
@@ -1,8 +1,8 @@
+#!/usr/bin/env python3
 import rospy
 
 class VelocityToOuttake():
 
-    rate = rospy.Rate(10)
     def __init__():
         rospy.init_node("velocity_to_outtake", anonymous=False)
 

--- a/src/vision.py
+++ b/src/vision.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+import rospy
+
+class Vision():
+    def __init__(self):
+        rospy.init_node("velocity_to_drive", anonymous=False)
+        self.rate = rospy.Rate(10)
+
+    def vision_vitals_publish(self):
+        shifter_publish = rospy.Publisher("vision_vitals_publish", "status_type", queue_size=10)
+        while not rospy.is_shutdown():
+            self.rate.sleep()


### PR DESCRIPTION
# ROS Nodes
----------------------------
### Purpose
This PR adds the creation of ROS node "skeleton"s. Essentially, it sets up the Publisher/Subscriber model outlined by the topic diagram.

### Change Log
- `driver.py`: Added goal_position, intake_control, outtake_control, and shifter_control publishers, along with the goal_status, shifter_status, vision_vitals, and magnet subscribers.
- - `odometry.py`: Added an odometry publisher.
- - `shifter.py`: added a shifter_status publisher and a shifter_control subscriber.
- - `velocity_to_drive.py`: Added a goal_status publisher, along with the odometry and goal_position subscribers
- - `velocity_to_intake.py`: Added intake_control subscriber.
- - `velocity_to_outtake.py`: Added outtake_control subscriber.
- 
### Testing
Look at the publisher and subscriber names to make sure everything is in check.

### Authors:
Kyle Kim